### PR TITLE
fix(NoticeBar): start scrolling when render

### DIFF
--- a/packages/core/src/notice-bar/notice-bar.tsx
+++ b/packages/core/src/notice-bar/notice-bar.tsx
@@ -11,6 +11,7 @@ import {
   ReactNode,
   useRef,
   useState,
+  useEffect
 } from "react"
 import { prefixClassname } from "../styles"
 import { useComputed } from "../utils/computed"
@@ -131,7 +132,8 @@ function NoticeBar(props: NoticeBarProps) {
     }, +delay)
   }
 
-  useReady(start)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(start, [])
 
   return (
     <View


### PR DESCRIPTION
NoticeBar 动态渲染（例如在 Tabs.TabPane 中），useReady 不会触发，使用只执行一次的 useEffect 解决。
