### PR TITLE
fix(Image): display none cause request twice

### DIFF
--- a/packages/core/src/image/image.scss
+++ b/packages/core/src/image/image.scss
@@ -16,7 +16,9 @@
   }
 
   &--loading {
-    display: none;
+    width: 0;
+    height: 0;
+    position: fixed;
   }
 
   &__fallback,


### PR DESCRIPTION
`display: none` 改变会导致对同一张图片再次发出请求，因此设置宽高为 0 达到相同效果，`position: fixed` 使图片在加载时脱离文档流，防止意外的 layout shifting

![image](https://user-images.githubusercontent.com/5123601/140293175-fd52cc7b-5ab5-4e69-9242-401f0dd1d271.png)
