### PR TITLE
bundle size reduction for demo package in development mode

### DIFF
--- a/packages/demo/config/dev.js
+++ b/packages/demo/config/dev.js
@@ -1,4 +1,5 @@
 // eslint-disable-next-line import/no-commonjs
+const TerserPlugin = require('terser-webpack-plugin');
 module.exports = {
   env: {
     // eslint-disable-next-line
@@ -46,6 +47,24 @@ module.exports = {
               },
             },
           },
+          // turn on below `minimize`, `minimizer` settings if bundle size is way too large
+          // to do remote debug in wechatdevtools
+          minimize: true,
+          minimizer: [
+            new TerserPlugin({
+              // add those `bundle`s your want to do size reduction
+              // refer to https://webpack.js.org/plugins/terser-webpack-plugin/#test
+              test: ['common.js', 'taro.js', 'vendors.js', 'lodash.js', 'taroify.js'],
+              parallel: true,
+              // minify: TerserPlugin.swcMinify,
+              cache: true,
+              extractComments: true,
+              parallel: true,
+              // should work with `mini.sourceMapType='source-map'`
+              // refer to https://webpack.js.org/plugins/terser-webpack-plugin/#note-about-source-maps
+              sourceMap: true,
+            }),
+          ]
         },
       });
       // enable webpack-bundle-analyzer
@@ -61,6 +80,9 @@ module.exports = {
       commonChunks.push('taroify')
       return commonChunks
     },
+    // turn to source-map if TerserPlugin is on
+    // refer to http://taro-docs.jd.com/taro/docs/config-detail/#minisourcemaptype
+    sourceMapType: 'source-map',
   },
   h5: {},
 }

--- a/packages/demo/config/dev.js
+++ b/packages/demo/config/dev.js
@@ -5,6 +5,62 @@ module.exports = {
     NODE_ENV: '"development"',
   },
   defineConstants: {},
-  mini: {},
+  mini: {
+    webpackChain(chain) {
+      // lodash bundle reduction
+      // `shorthands`, `coercions`, `paths` are necessary to avoid some weird things
+      chain.plugin('lodash-webpack-plugin')
+        .use(require('lodash-webpack-plugin'), [{
+          shorthands: true,
+          cloning: true,
+          caching: true,
+          collections: true,
+          exotics: true,
+          guards: true,
+          memoizing: true,
+          coercions: true,
+          flattening: true,
+          paths: true,
+        }]);
+
+      chain.merge({
+        optimization: {
+          splitChunks: {
+            // `all` or `initial`, `all` will have the smallest overall size, refer to
+            // https://stackoverflow.com/questions/50127185/webpack-what-is-the-difference-between-all-and-initial-options-in-optimizat
+            chunks: 'all',
+            cacheGroups: {
+              lodash: {
+                name: 'lodash',
+                priority: 100,
+                test(module) {
+                  return /node_modules[\\/]lodash/.test(module.context)
+                },
+              },
+              taroify: {
+                name: 'taroify',
+                test: /node_modules[\\/]@taroify/,
+                // just higher than 10 will be fine, refer to
+                // https://github.com/NervJS/taro/blob/bc6af68bda2cbc9163fbda36c15878fc96aec8f1/packages/taro-mini-runner/src/webpack/build.conf.ts#L220-L254
+                priority: 100,
+              },
+            },
+          },
+        },
+      });
+      // enable webpack-bundle-analyzer
+      // if you would like to do some bundle reduction stuff
+      chain.plugin('analyzer')
+        .use(require('webpack-bundle-analyzer').BundleAnalyzerPlugin, [{
+          analyzerPort: 'auto',
+          generateStatsFile: true,
+        }])
+    },
+    commonChunks(commonChunks) {
+      commonChunks.push('lodash')
+      commonChunks.push('taroify')
+      return commonChunks
+    },
+  },
   h5: {},
 }

--- a/packages/demo/config/index.js
+++ b/packages/demo/config/index.js
@@ -36,61 +36,6 @@ const config = {
         },
       },
     },
-    webpackChain(chain) {
-      // lodash bundle reduction
-      // `shorthands`, `coercions`, `paths` are necessary to avoid some weird things
-      chain.plugin('lodash-webpack-plugin')
-        .use(require('lodash-webpack-plugin'), [{
-          shorthands: true,
-          cloning: true,
-          caching: true,
-          collections: true,
-          exotics: true,
-          guards: true,
-          memoizing: true,
-          coercions: true,
-          flattening: true,
-          paths: true,
-        }]);
-
-      chain.merge({
-        optimization: {
-          splitChunks: {
-            // `all` or `initial`, `all` will have the smallest overall size, refer to
-            // https://stackoverflow.com/questions/50127185/webpack-what-is-the-difference-between-all-and-initial-options-in-optimizat
-            chunks: 'all',
-            cacheGroups: {
-              lodash: {
-                name: 'lodash',
-                priority: 100,
-                test(module) {
-                  return /node_modules[\\/]lodash/.test(module.context)
-                },
-              },
-              taroify: {
-                name: 'taroify',
-                test: /node_modules[\\/]@taroify/,
-                // just higher than 10 will be fine, refer to
-                // https://github.com/NervJS/taro/blob/bc6af68bda2cbc9163fbda36c15878fc96aec8f1/packages/taro-mini-runner/src/webpack/build.conf.ts#L220-L254
-                priority: 100,
-              },
-            },
-          },
-        },
-      });
-      // enable webpack-bundle-analyzer
-      // if you would like to do some bundle reduction stuff
-      chain.plugin('analyzer')
-        .use(require('webpack-bundle-analyzer').BundleAnalyzerPlugin, [{
-          analyzerPort: 'auto',
-          generateStatsFile: true,
-        }])
-    },
-    commonChunks(commonChunks) {
-      commonChunks.push('lodash')
-      commonChunks.push('taroify')
-      return commonChunks
-    },
   },
   h5: {
     esnextModules: ["@taroify"],

--- a/packages/demo/config/index.js
+++ b/packages/demo/config/index.js
@@ -36,6 +36,61 @@ const config = {
         },
       },
     },
+    webpackChain(chain) {
+      // lodash bundle reduction
+      // `shorthands`, `coercions`, `paths` are necessary to avoid some weird things
+      chain.plugin('lodash-webpack-plugin')
+        .use(require('lodash-webpack-plugin'), [{
+          shorthands: true,
+          cloning: true,
+          caching: true,
+          collections: true,
+          exotics: true,
+          guards: true,
+          memoizing: true,
+          coercions: true,
+          flattening: true,
+          paths: true,
+        }]);
+
+      chain.merge({
+        optimization: {
+          splitChunks: {
+            // `all` or `initial`, `all` will have the smallest overall size, refer to
+            // https://stackoverflow.com/questions/50127185/webpack-what-is-the-difference-between-all-and-initial-options-in-optimizat
+            chunks: 'all',
+            cacheGroups: {
+              lodash: {
+                name: 'lodash',
+                priority: 100,
+                test(module) {
+                  return /node_modules[\\/]lodash/.test(module.context)
+                },
+              },
+              taroify: {
+                name: 'taroify',
+                test: /node_modules[\\/]@taroify/,
+                // just higher than 10 will be fine, refer to
+                // https://github.com/NervJS/taro/blob/bc6af68bda2cbc9163fbda36c15878fc96aec8f1/packages/taro-mini-runner/src/webpack/build.conf.ts#L220-L254
+                priority: 100,
+              },
+            },
+          },
+        },
+      });
+      // enable webpack-bundle-analyzer
+      // if you would like to do some bundle reduction stuff
+      chain.plugin('analyzer')
+        .use(require('webpack-bundle-analyzer').BundleAnalyzerPlugin, [{
+          analyzerPort: 'auto',
+          generateStatsFile: true,
+        }])
+    },
+    commonChunks(commonChunks) {
+      commonChunks.push('lodash')
+      commonChunks.push('taroify')
+      return commonChunks
+    },
   },
   h5: {
     esnextModules: ["@taroify"],

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -66,8 +66,10 @@
     "eslint-plugin-import": "^2.12.0",
     "eslint-plugin-react": "^7.8.2",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "lodash-webpack-plugin": "^0.11.6",
     "sass": "^1.34.0",
     "stylelint": "9.3.0",
-    "typescript": "^4.1.0"
+    "typescript": "^4.1.0",
+    "webpack-bundle-analyzer": "^4.5.0"
   }
 }


### PR DESCRIPTION
# Highlight
Total bundle size in development mode 3.5MB -> 1.78MB (almost **50% off**)
> based on a few commits after 0.0.17-alpha.1, commit: 9ef31ef280b247c232ac7990f22c690b59b2bb8d 

There is **_NO NEED_** to turn on terser plugin for the demo package taking belows into account:
* enable remote debugging in various mini-program devtools with full source map support under bundle size limit of 2MB
* we configure the terser plugin to minimize the SELECTED BUNDLES ONLY

# Comparison
![image](https://user-images.githubusercontent.com/1177332/140590007-39a78c9a-c3a2-4ee9-be0c-4a4253e2039c.png)

# Code
首页见

