### PR TITLE
fix(Image): lazyLoad broken in scrollView

### DIFF
--- a/packages/core/src/image/image.scss
+++ b/packages/core/src/image/image.scss
@@ -16,7 +16,7 @@
   }
 
   &--loading {
-    position: fixed;
+    position: absolute;
     width: 0;
     height: 0;
   }


### PR DESCRIPTION
`position: fixed` 导致 Image 在滚动列表中不加载