### PR TITLE
createNodesRef 微信小程序跨自定义组件

### DIFF
--- a/packages/core/src/utils/dom/element.ts
+++ b/packages/core/src/utils/dom/element.ts
@@ -1,6 +1,7 @@
 import type { TaroElement } from "@tarojs/runtime"
 import { createSelectorQuery } from "@tarojs/taro"
 import * as _ from "lodash"
+import { inWechat } from "../base"
 
 export const ELEMENT_NODE_TYPE = 1
 
@@ -34,8 +35,23 @@ export function createNodesRef(elementOrRef: any) {
   if (_.isString(elementOrRef)) {
     return createSelectorQuery().select("#" + elementOrRef)
   }
+
   const element = elementUnref(elementOrRef)
-  return isRootElement(element)
-    ? createSelectorQuery().selectViewport()
-    : createSelectorQuery().select("#" + element.uid)
+
+  if (isRootElement(element)) {
+    return createSelectorQuery().selectViewport()
+  }
+
+  if (inWechat) {
+    let parentNode = element;
+    while (parentNode.parentNode && !isRootElement(parentNode.parentNode)) {
+      parentNode = parentNode.parentNode
+    }
+
+    if (parentNode && parentNode !== element) {
+      return createSelectorQuery().select(`#${parentNode.uid}>>>#${element.uid}`)
+    }
+  }
+
+  return  createSelectorQuery().select("#" + element.uid)
 }


### PR DESCRIPTION
使用CustomWarpper组件后，会造成DropdownMenu无法使用，应该是跨自定义组件无法直接使用#id选择器。
https://developers.weixin.qq.com/miniprogram/dev/api/wxml/SelectorQuery.select.html

我简单尝试着修复了一下， 但没有详细验证影响的范围， 所以仅供参考吧