### PR TITLE
[Calendar] Fix "This expression is not callable"

### DIFF
--- a/packages/core/src/calendar/calendar.tsx
+++ b/packages/core/src/calendar/calendar.tsx
@@ -1,7 +1,7 @@
 import { ScrollView, View } from "@tarojs/components"
 import { ViewProps } from "@tarojs/components/types/View"
 import { nextTick } from "@tarojs/taro"
-import * as classNames from "classnames"
+import classNames from "classnames"
 import * as _ from "lodash"
 import * as React from "react"
 import {


### PR DESCRIPTION
修复构建项目时ts类型报错问题

Node：v16.13.1

[10:41:04] Starting 'compile typescript files to bundles/core from packages/core'...
packages/core/src/calendar/calendar.tsx(425,20): error TS2349: This expression is not callable.
  Type 'typeof import("/Users/liankaa/Documents/www/new_liankaa/taroify/node_modules/classnames/index")' has no call signatures.
TypeScript: 1 semantic error
TypeScript: emit succeeded (with errors)
[10:41:09] 'compile typescript files to bundles/core from packages/core' errored after 4.83 s
[10:41:09] Error: TypeScript: Compilation failed
    at Output.mightFinish (/Users/liankaa/Documents/www/new_liankaa/taroify/node_modules/gulp-typescript/release/output.js:131:43)
    at /Users/liankaa/Documents/www/new_liankaa/taroify/node_modules/gulp-typescript/release/output.js:44:22
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
[10:41:09] 'build' errored after 16 s
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.