### PR TITLE
fix: fix field component inputAlign=right not work in h5

### DIFF
--- a/packages/core/src/field/field.scss
+++ b/packages/core/src/field/field.scss
@@ -112,7 +112,9 @@
       text-align: center;
     }
 
-    &--right {
+    &--right,
+    &--right input,
+    &--right textarea{
       justify-content: flex-end;
       text-align: right;
     }


### PR DESCRIPTION
修复field组件inputAlign=right 在h5下不起作用的Bug