### PR TITLE
fix: fix badge bug 

### DIFF
--- a/packages/core/src/badge/badge.tsx
+++ b/packages/core/src/badge/badge.tsx
@@ -34,7 +34,7 @@ function Badge(props: BadgeProps): JSX.Element {
       <>
         {!isIcon && children}
         {noneChildren && !dot && content}
-        {hasChildren && (dot || content) && (
+        {hasChildren && (dot || (content || content !== 0) ) && (
           <View
             className={classNames(
               prefixClassname("badge"),


### PR DESCRIPTION
修复badge在content={0}，dot={false}时会直接渲染一个0而不是渲染后面的view的bug