### PR TITLE
[Badge] Fix rendering to 0 when content is 0

### DIFF
--- a/packages/core/src/badge/badge.tsx
+++ b/packages/core/src/badge/badge.tsx
@@ -34,7 +34,7 @@ function Badge(props: BadgeProps): JSX.Element {
       <>
         {!isIcon && children}
         {noneChildren && !dot && content}
-        {hasChildren && (dot || content) && (
+        {hasChildren && (dot || (content || content !== 0) ) && (
           <View
             className={classNames(
               prefixClassname("badge"),

--- a/packages/core/src/badge/badge.tsx
+++ b/packages/core/src/badge/badge.tsx
@@ -19,8 +19,10 @@ function Badge(props: BadgeProps): JSX.Element {
   const isIcon = useMemo(() => isIconElement(children), [children])
   const hasChildren = children !== undefined
   const noneChildren = children === undefined
-  const content = _.isNumber(contentProp) && _.gt(contentProp, max) ? `${max}+` : contentProp
-
+  let content = _.isNumber(contentProp) && _.gt(contentProp, max) ? `${max}+` : contentProp
+  if (content === 0) {
+    content = "0"
+  }
   return cloneIconElement(isIcon ? children : <View />, {
     className: classNames(
       {
@@ -34,7 +36,7 @@ function Badge(props: BadgeProps): JSX.Element {
       <>
         {!isIcon && children}
         {noneChildren && !dot && content}
-        {hasChildren && (dot || (content || content !== 0) ) && (
+        {hasChildren && (dot || content) && (
           <View
             className={classNames(
               prefixClassname("badge"),


### PR DESCRIPTION
修复badge 在content={0} dot={false}下会直接渲染一个0而不是渲染后面的View的bug