### PR TITLE
[SafeArea] Add compatibility constant function

### DIFF
--- a/packages/core/src/safe-area/safe-area.scss
+++ b/packages/core/src/safe-area/safe-area.scss
@@ -6,10 +6,12 @@
   width: 100%;
 
   &--top {
-    padding-top: env(safe-area-inset-top);
+    padding-top: constant(safe-area-inset-top); /* 兼容 iOS < 11.2 */
+    padding-top: env(safe-area-inset-top); /* 兼容 iOS >= 11.2 */
   }
 
   &--bottom {
-    padding-bottom: env(safe-area-inset-bottom);
+    padding-bottom: constant(safe-area-inset-bottom); /* 兼容 iOS < 11.2 */
+    padding-bottom: env(safe-area-inset-bottom); /* 兼容 iOS >= 11.2 */
   }
 }


### PR DESCRIPTION
safeArea  添加兼容性 css 函数

_**The env() function shipped in iOS 11 with the name constant(). Beginning with Safari Technology Preview 41 and the iOS 11.2 beta, constant() has been removed and replaced with env(). You can use the CSS fallback mechanism to support both versions, if necessary, but should prefer env() going forward.**_