### PR TITLE
[ancestorCustomWrapper] Fix getRect nested in a Block element does not query elements

### DIFF
--- a/packages/core/src/utils/dom/element.ts
+++ b/packages/core/src/utils/dom/element.ts
@@ -27,8 +27,8 @@ export function isRootElement(node?: TaroElement) {
   return node?.nodeType === ELEMENT_NODE_TYPE && node?.tagName === "ROOT"
 }
 
-export function isBlockElement(node?: TaroElement) {
-  return node?.nodeType === ELEMENT_NODE_TYPE && node?.tagName === "BLOCK"
+export function isValidElement(node?: TaroElement) {
+  return ["BLOCK"].includes(node?.tagName)
 }
 
 export function matchSelector(aSelector?: string, bSelector?: string) {
@@ -60,17 +60,18 @@ export function usePrependPageSelector(selector?: string) {
 // See: https://github.com/mallfoundry/taroify/pull/143
 function ancestorCustomWrapper(element: TaroElement) {
   if (inWechat) {
+    let pointer = element
     let ancestor = element
 
-    while (ancestor.parentNode) {
+    while (pointer.parentNode) {
 
-      if (isRootElement(ancestor.parentNode)) break
+      if (isRootElement(pointer.parentNode)) break
 
-      if (isBlockElement(ancestor.parentNode)) {
-        if (isRootElement(ancestor.parentNode.parentNode)) break
+      if (isValidElement(pointer.parentNode)) {
+        ancestor = pointer.parentNode
       }
 
-      ancestor = ancestor.parentNode as TaroElement
+      pointer = pointer.parentNode as TaroElement
     }
 
     if (ancestor && ancestor !== element) {

--- a/packages/core/src/utils/dom/element.ts
+++ b/packages/core/src/utils/dom/element.ts
@@ -27,8 +27,8 @@ export function isRootElement(node?: TaroElement) {
   return node?.nodeType === ELEMENT_NODE_TYPE && node?.tagName === "ROOT"
 }
 
-export function isValidElement(node?: TaroElement) {
-  return !["BLOCK"].includes(node?.tagName)
+export function isBlockElement(node?: TaroElement) {
+  return node && !["BLOCK"].includes(node?.tagName)
 }
 
 export function matchSelector(aSelector?: string, bSelector?: string) {

--- a/packages/core/src/utils/dom/element.ts
+++ b/packages/core/src/utils/dom/element.ts
@@ -67,7 +67,7 @@ function ancestorCustomWrapper(element: TaroElement) {
 
       if (isRootElement(pointer.parentNode)) break
 
-      if (isValidElement(pointer.parentNode)) {
+      if (!isBlockElement(pointer.parentNode)) {
         ancestor = pointer.parentNode
       }
 

--- a/packages/core/src/utils/dom/element.ts
+++ b/packages/core/src/utils/dom/element.ts
@@ -27,8 +27,8 @@ export function isRootElement(node?: TaroElement) {
   return node?.nodeType === ELEMENT_NODE_TYPE && node?.tagName === "ROOT"
 }
 
-export function isValidElement(node?: TaroElement) {
-  return node && !["BLOCK"].includes(node?.tagName)
+export function isBlockElement(node?: TaroElement) {
+  return node?.nodeType === ELEMENT_NODE_TYPE && node?.tagName === "BLOCK"
 }
 
 export function matchSelector(aSelector?: string, bSelector?: string) {
@@ -67,7 +67,7 @@ function ancestorCustomWrapper(element: TaroElement) {
 
       if (isRootElement(pointer.parentNode)) break
 
-      if (isValidElement(pointer.parentNode)) {
+      if (!isBlockElement(pointer.parentNode)) {
         ancestor = pointer.parentNode
       }
 

--- a/packages/core/src/utils/dom/element.ts
+++ b/packages/core/src/utils/dom/element.ts
@@ -28,7 +28,7 @@ export function isRootElement(node?: TaroElement) {
 }
 
 export function isValidElement(node?: TaroElement) {
-  return ["BLOCK"].includes(node?.tagName)
+  return !["BLOCK"].includes(node?.tagName)
 }
 
 export function matchSelector(aSelector?: string, bSelector?: string) {

--- a/packages/core/src/utils/dom/element.ts
+++ b/packages/core/src/utils/dom/element.ts
@@ -27,7 +27,7 @@ export function isRootElement(node?: TaroElement) {
   return node?.nodeType === ELEMENT_NODE_TYPE && node?.tagName === "ROOT"
 }
 
-export function isBlockElement(node?: TaroElement) {
+export function isValidElement(node?: TaroElement) {
   return node && !["BLOCK"].includes(node?.tagName)
 }
 
@@ -67,7 +67,7 @@ function ancestorCustomWrapper(element: TaroElement) {
 
       if (isRootElement(pointer.parentNode)) break
 
-      if (!isBlockElement(pointer.parentNode)) {
+      if (isValidElement(pointer.parentNode)) {
         ancestor = pointer.parentNode
       }
 

--- a/packages/core/src/utils/dom/element.ts
+++ b/packages/core/src/utils/dom/element.ts
@@ -27,6 +27,10 @@ export function isRootElement(node?: TaroElement) {
   return node?.nodeType === ELEMENT_NODE_TYPE && node?.tagName === "ROOT"
 }
 
+export function isBlockElement(node?: TaroElement) {
+  return node?.nodeType === ELEMENT_NODE_TYPE && node?.tagName === "BLOCK"
+}
+
 export function matchSelector(aSelector?: string, bSelector?: string) {
   return aSelector === bSelector
 }
@@ -57,7 +61,15 @@ export function usePrependPageSelector(selector?: string) {
 function ancestorCustomWrapper(element: TaroElement) {
   if (inWechat) {
     let ancestor = element
-    while (ancestor.parentNode && !isRootElement(ancestor.parentNode as TaroElement)) {
+
+    while (ancestor.parentNode) {
+
+      if (isRootElement(ancestor.parentNode)) break
+
+      if (isBlockElement(ancestor.parentNode)) {
+        if (isRootElement(ancestor.parentNode.parentNode)) break
+      }
+
       ancestor = ancestor.parentNode as TaroElement
     }
 


### PR DESCRIPTION
当页面的根元素为 `Block` 时，`createSelectorQuery().select("#".concat(ancestor.uid, ">>>#").concat(element.uid))` 查询不到信息。导致控制台报错
```tsx
import { Block } from '@tarojs/components'

export default function () {
  return (
    <Block>
      <Calendar type="single" />
    </Block>
  )
}
```

![image](https://user-images.githubusercontent.com/22864183/154812640-8ba23fd1-d97e-4ec7-8252-eebd37e08c14.png)
