### PR TITLE
fix: remove redundant css

### DIFF
--- a/packages/core/src/styles/_variables.scss
+++ b/packages/core/src/styles/_variables.scss
@@ -36,7 +36,6 @@ $danger-color: var(--red, $red);
 $text-color: var(--gray-8, $gray-8);
 $text-color-2: var(--gray-6, $gray-6);
 $text-color-3: var(--gray-5, $gray-5);
-$text-link-color: #576b95;
 $active-color: var(--gray-2, $gray-2);
 $active-opacity: 0.7;
 $disabled-opacity: 0.5;


### PR DESCRIPTION
This property is declared twice. So delete one.