### PR TITLE
fix: alipay Click Event detail

### DIFF
--- a/packages/core/src/utils/dom/event.ts
+++ b/packages/core/src/utils/dom/event.ts
@@ -27,7 +27,7 @@ interface ClientCoordinates {
 
 export function getClientCoordinates(event: ITouchEvent | MouseEvent): ClientCoordinates {
   // @ts-ignore
-  const { clientX, clientY, touches } = event
+  const { clientX, clientY, touches, detail } = event
 
   if (clientX && clientY) {
     return {
@@ -35,5 +35,5 @@ export function getClientCoordinates(event: ITouchEvent | MouseEvent): ClientCoo
       clientY,
     }
   }
-  return touches[0]
+  return detail;
 }


### PR DESCRIPTION
支付宝小程序不返回 touches，如果没有clientX 和 clientY，则从 detail 中获取