### PR TITLE
fix：WeChat mini program Click Event detail

### DIFF
--- a/packages/core/src/utils/dom/event.ts
+++ b/packages/core/src/utils/dom/event.ts
@@ -27,7 +27,7 @@ interface ClientCoordinates {
 
 export function getClientCoordinates(event: ITouchEvent | MouseEvent): ClientCoordinates {
   // @ts-ignore
-  const { clientX, clientY, detail } = event
+  const { clientX, clientY, detail = {}, touchs = [] } = event
 
   if (clientX && clientY) {
     return {
@@ -35,5 +35,5 @@ export function getClientCoordinates(event: ITouchEvent | MouseEvent): ClientCoo
       clientY,
     }
   }
-  return detail;
+  return touchs[0] || { clientX: detail.x || detail.clientX, clientY: detail.y || detail.clientY };
 }


### PR DESCRIPTION
由于使用微信小程序点击右侧导航，定位报错，发现是上一个人为了支持支付宝，把微信改坏了，所以修改一下