### PR TITLE
fix(taroify/core/button): button组件出现 Warning: Each child in a list sh…

### DIFF
--- a/packages/core/src/button/button.tsx
+++ b/packages/core/src/button/button.tsx
@@ -92,7 +92,7 @@ function useButtonChildren(options: UseButtonChildrenOptions = {}) {
             return appendButtonIconClassname(child, prefixClassname("button__icon--left"))
           }
           return (
-            <View className={prefixClassname("button__text")}>{child}</View>
+            <View key={index} className={prefixClassname("button__text")}>{child}</View>
           )
         })
       }


### PR DESCRIPTION
…ould have a unique "key" prop

在开发模式下，使用Button组件时会出现以下警告信息：
  Warning: Each child in a list should have a unique “key” prop.

React在循环显示组件时需要提供key值，以避免重复渲染；See https://reactjs.org/link/warning-keys for more information.

加入 key={index} 经测试不再出现警告信息。

fix #595