### PR TITLE
Fix/tabs lazy render

### DIFF
--- a/packages/core/src/tabs/index.ts
+++ b/packages/core/src/tabs/index.ts
@@ -2,7 +2,7 @@ import TabPane from "./tab-pane"
 import TabsElement, { TabsProps } from "./tabs"
 import { TabEvent as SharedTabEvent } from "./tabs.shared"
 
-export type { TabThemeVars } from './tabs.shared'
+export type { TabThemeVars } from "./tabs.shared"
 
 interface TabsInterface {
   (props: TabsProps): JSX.Element

--- a/packages/core/src/tabs/tab-pane-base.tsx
+++ b/packages/core/src/tabs/tab-pane-base.tsx
@@ -17,7 +17,7 @@ interface TabPaneBaseProps extends ViewProps {
 
 export default function TabPaneBase(props: TabPaneBaseProps) {
   const { className, style, index, value, children, ...restProps } = props
-  const { index: activeIndex, value: activeValue, lazyRender, animated, swipeable } = useContext(
+  const { value: activeValue, lazyRender, animated, swipeable } = useContext(
     TabsContext,
   )
 
@@ -34,16 +34,11 @@ export default function TabPaneBase(props: TabPaneBaseProps) {
       return true
     }
 
-    if ((index - 1 === activeIndex || index + 1 === activeIndex) && !initializedRef.current) {
-      initializedRef.current = true
-      return true
-    }
-
     if (active && !initializedRef.current) {
       initializedRef.current = true
     }
     return active
-  }, [active, activeIndex, index, lazyRender])
+  }, [active, lazyRender])
 
   const tabPane = (
     <View

--- a/packages/core/src/tabs/tabs.shared.ts
+++ b/packages/core/src/tabs/tabs.shared.ts
@@ -1,4 +1,4 @@
-import { Key, ReactNode } from "react"
+import { ReactNode } from "react"
 
 export type TabsTheme = "line" | "card"
 
@@ -9,7 +9,7 @@ export interface TabEvent {
 }
 
 export interface TabObject {
-  key: Key
+  key: string | number
   index: number
   value: any
   className?: string

--- a/packages/core/src/tabs/tabs.tsx
+++ b/packages/core/src/tabs/tabs.tsx
@@ -159,7 +159,7 @@ function Tabs(props: TabsProps) {
         onTabClick={handleTabClick}
       />
     ),
-    [bordered, ellipsis, handleTabClick, tabObjects, theme, value],
+    [bordered, ellipsis, handleTabClick, tabObjects, theme, value, swipeThreshold],
   )
 
   return (


### PR DESCRIPTION
Tabs设置lazyRender属性后，会加载当前，前后选项卡，和预期不符(延迟渲染未展示的选项卡)