### PR TITLE
Update watermark.tsx (index.scss import removed)

### DIFF
--- a/packages/core/src/watermark/watermark.tsx
+++ b/packages/core/src/watermark/watermark.tsx
@@ -5,7 +5,6 @@ import { getEnv, getWindowInfo } from "@tarojs/taro"
 import cls from "classnames"
 import { useCanvas } from "../hooks"
 import { prefixClassname } from "../styles"
-import "./index.scss"
 
 type WatermarkProps = Partial<{
   gapX: number


### PR DESCRIPTION
Importing .scss file inside the component is causing an error while using it inside a taro project.