### PR TITLE
fix: font-size of input cannot be inherited

### DIFF
--- a/packages/core/src/input/native-input.scss
+++ b/packages/core/src/input/native-input.scss
@@ -11,6 +11,7 @@
   resize: inherit;
   background: inherit;
   border: inherit;
+  font-size: inherit;
 
   // for ios wechat
   &[type='date'],


### PR DESCRIPTION
修复 Input 组件的 font-size 无法被正常继承。

![image](https://github.com/mallfoundry/taroify/assets/12469549/73a168f2-e789-4800-9098-2e3f50b21cac)
