### PR TITLE
Fix/test cases

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,10 +4,21 @@
  */
 
 module.exports = {
+  globals: {
+    window: true,
+    DEPRECATED_ADAPTER_COMPONENT: false,
+    ENABLE_INNER_HTML: true,
+    ENABLE_ADJACENT_HTML: true,
+    ENABLE_SIZE_APIS: true,
+    ENABLE_TEMPLATE_CONTENT: true,
+    ENABLE_CLONE_NODE: true,
+    ENABLE_CONTAINS: true,
+    ENABLE_MUTATION_OBSERVER: true,
+  },
   clearMocks: true,
   coverageDirectory: "coverage",
   moduleNameMapper: {
-    "@tarojs/components": "@tarojs/components/dist-h5/react",
+    '@tarojs/components': '@tarojs/components/lib/react',
   },
   setupFilesAfterEnv: ["<rootDir>/jest/jest-setup.ts"],
   testEnvironment: "jest-environment-jsdom",

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,7 +18,7 @@ module.exports = {
   clearMocks: true,
   coverageDirectory: "coverage",
   moduleNameMapper: {
-    '@tarojs/components': '@tarojs/components/lib/react',
+    "@tarojs/components": "@tarojs/components/lib/react",
   },
   setupFilesAfterEnv: ["<rootDir>/jest/jest-setup.ts"],
   testEnvironment: "jest-environment-jsdom",

--- a/packages/core/src/navbar/__tests__/navbar.test.tsx
+++ b/packages/core/src/navbar/__tests__/navbar.test.tsx
@@ -1,7 +1,7 @@
 import { render } from "@testing-library/react"
 import * as React from "react"
 import { prefixClassname } from "../../styles"
-import { HAIRLINE_BOTTOM } from "../../styles/hairline"
+import { HAIRLINE_BORDER_BOTTOM } from "../../styles/hairline"
 import Navbar from "../navbar"
 
 describe("<Navbar />", () => {
@@ -15,6 +15,6 @@ describe("<Navbar />", () => {
   it("should have hairline--bottom of classNames", () => {
     const { container } = render(<Navbar bordered />)
     const el = container.querySelector(`.${prefixClassname("navbar")}`)
-    expect(el).toHaveClass(HAIRLINE_BOTTOM)
+    expect(el).toHaveClass(HAIRLINE_BORDER_BOTTOM)
   })
 })


### PR DESCRIPTION
This PR is to fix test cases. Currently if you're running 

```bash
yarn test
```

it's throwing various errors 

``` bash
 ReferenceError: DEPRECATED_ADAPTER_COMPONENT is not defined
 ReferenceError: ENABLE_INNER_HTML is not defined
```
To fix this, globals has been added. Here is the reference link: https://docs.taro.zone/docs/external-libraries/#jest.

Next fix is to map ```@tarojs/components``` correctly. Currently in ```jest.config.js``` it was mapped to ```@tarojs/components/dist-h5/react```. Due to which running ```yarn test``` was throwing below error.

```bash
Please check your configuration for these entries:
{
  "moduleNameMapper": {
    "/@tarojs\/components/": "@tarojs/components/dist-h5/react"
  },
  "resolver": undefined
}
```

But this path doesn't exists. Now it should be mapped to ```@tarojs/components/lib/react```, like

```javascript
// jest.config.js
{
  moduleNameMapper: {
    '@tarojs/components': '@tarojs/components/lib/react',
  }
}
```

Last fix is for ```packages/core/src/navbar/__tests__/navbar.test.tsx``` where invalid constant was exported from styles. Now it's corrected to ```import { HAIRLINE_BORDER_BOTTOM } from "../../styles/hairline"```


