### PR TITLE
Fix/swiper

### DIFF
--- a/packages/core/src/tabs/tabs-header.tsx
+++ b/packages/core/src/tabs/tabs-header.tsx
@@ -101,6 +101,8 @@ export default function TabsHeader(props: TabsHeaderProps) {
       )}
     >
       <ScrollView
+        enhanced
+        showScrollbar={false}
         scrollX={tabObjects.length > swipeThreshold || !ellipsis}
         scrollWithAnimation
         scrollLeft={scrollLeft}


### PR DESCRIPTION
1.修复SwiperItem初始化后再渲染
2.修复在微信上TabsHeader滚动时，不应显示滚动条