### PR TITLE
fix: fix pick-column scroll stuck issue

### DIFF
--- a/packages/core/src/picker/picker-column.tsx
+++ b/packages/core/src/picker/picker-column.tsx
@@ -13,7 +13,7 @@ import {
   useState,
 } from "react"
 import { prefixClassname } from "../styles"
-import { getComputedStyle } from "../utils/dom/computed-style"
+// import { getComputedStyle } from "../utils/dom/computed-style"
 import { preventDefault } from "../utils/dom/event"
 import { addUnitPx } from "../utils/format/unit"
 import { fulfillPromise } from "../utils/promisify"
@@ -29,13 +29,13 @@ const MOMENTUM_LIMIT_TIME = 300
 const MOMENTUM_LIMIT_DISTANCE = 15
 const DEFAULT_DURATION = 200
 
-async function getElementTranslateY(element: Element) {
-  const style = await getComputedStyle(element, ["transform", "webkitTransform"])
-  const transform = style.transform || style.webkitTransform
-  const translateY = transform.slice(7, transform.length - 1).split(", ")[5]
+// async function getElementTranslateY(element: Element) {
+//   const style = await getComputedStyle(element, ["transform", "webkitTransform"])
+//   const transform = style.transform || style.webkitTransform
+//   const translateY = transform.slice(7, transform.length - 1).split(", ")[5]
 
-  return Number(translateY)
-}
+//   return Number(translateY)
+// }
 
 // type PickerColumnDuration = "zero" | "switch" | "momentum"
 


### PR DESCRIPTION
修复 picker 组件在快速上滑或者下滑时，执行惯性动画期间，再次滚动 picker-column 后出现的位置卡顿问题。

### 具体原因：
当判断进入 momentum 方法时，由于进入到惯性动画，此时 css3 transition duration 的值从原来的 200ms 变为 1s，大大延长了 onTransitionEnd 事件触发的时机，进而增加了 handleTouchStart 中 movingRef.current 为 true 的情况，即当 css3 动画还没有执行完时，又再次滑动 picker-columns 的情形。经过分析了 handleTouchStart 中 movingRef.current 为 true 的情况，发现其中一个 异步获取 translateY 的地方会导致紧随其后的 setActiveOffset(offset) 执行时机延迟，导致 这个 handleTouchStart 中的 setState 有概率会在 handleTouchEnd 后执行，从而覆盖了 handleTouchEnd 中 setIndex 里执行的 setActiveOffset(offset) ，最终导致 pick-columns 卡在中间位置上。

### 解决方案
去掉从 getElementTranslateY 函数获取 translateY 的值，改用 useRef 手动记录 touchMove 时滑动过的距离和惯性函数计算后最终的距离，当然这样计算并不能完全等同于 translateY 的值，但经过测试发现其两者的数值差别并不大，且获取该数值的用处是一致的。