### PR TITLE
build: tree shaking lodash

### DIFF
--- a/packages/core/src/pull-refresh/pull-refresh.tsx
+++ b/packages/core/src/pull-refresh/pull-refresh.tsx
@@ -31,12 +31,6 @@ import {
 } from "./pull-refresh-children"
 import PullRefreshContext from "./pull-refresh.context"
 
-const lodashRoot = require("lodash/_root")
-
-if (typeof lodashRoot.Date === "undefined") {
-  lodashRoot.Date = Date
-}
-
 enum PullRefreshStatus {
   Awaiting = "awaiting",
   Pulling = "pulling",

--- a/packages/gulp/__tests__/treeshaking-lodash.test.js
+++ b/packages/gulp/__tests__/treeshaking-lodash.test.js
@@ -1,0 +1,17 @@
+import { treeShakingLodash } from "../treeshaking-lodash"
+
+describe("treeShakingLodash", () => {
+  it("treeShakingLodash", () => {
+    expect(treeShakingLodash(`
+import { debounce, throttle, get as mGet } from "lodash";
+import * as _ from "lodash";
+import util from "lodash";
+console.log(mGet(), util.set(), _.map())`)).toEqual(`
+import debounce from "lodash/debounce";
+import throttle from "lodash/throttle";
+import mGet from "lodash/get";
+import _map from "lodash/map";
+import utilset from "lodash/set";
+console.log(mGet(), utilset(), _map())`)
+  })
+})


### PR DESCRIPTION
将
```js
import { debounce, throttle, get as mGet } from "lodash";
import * as _ from "lodash";
import util from "lodash";
console.log(mGet(), util.set(), _.map())
```
转换为
```js
import debounce from "lodash/debounce";
import throttle from "lodash/throttle";
import mGet from "lodash/get";
import _map from "lodash/map";
import utilset from "lodash/set";
console.log(mGet(), utilset(), _map())
```

已知以下为处理(代码里不存在)
1.lodash/fp
2.import "lodash"
3.import { get as _get } from "lodash"; import _ as from "lodash"; console.log(_get(), _.get())