### PR TITLE
[TextArea]: getStringLength

### DIFF
--- a/packages/core/src/textarea/textarea.shared.ts
+++ b/packages/core/src/textarea/textarea.shared.ts
@@ -12,5 +12,5 @@ export type TextareaThemeVars = {
 }
 
 export function getStringLength(chars: string = "") {
-  return _.size([...chars])
+  return chars.normalize().length
 }


### PR DESCRIPTION
fix(Textarea): getStringLength return incorrect in emoji

getStringLength在输入emoji时无法正确统计字符长度