### PR TITLE
fix(lodash): replace CallExpression with MemberExpression

### DIFF
--- a/packages/gulp/__tests__/treeshaking-lodash.test.js
+++ b/packages/gulp/__tests__/treeshaking-lodash.test.js
@@ -6,12 +6,16 @@ describe("treeShakingLodash", () => {
 import { debounce, throttle, get as mGet } from "lodash";
 import * as _ from "lodash";
 import util from "lodash";
-console.log(mGet(), util.set(), _.map())`)).toEqual(`
+const maxOrMin = true ? _.max : _.min
+console.log(mGet(), util.set(), _.map(), maxOrMin())`)).toEqual(`
 import debounce from "lodash/debounce";
 import throttle from "lodash/throttle";
 import mGet from "lodash/get";
+import _max from "lodash/max";
+import _min from "lodash/min";
 import _map from "lodash/map";
 import utilset from "lodash/set";
-console.log(mGet(), utilset(), _map())`)
+const maxOrMin = true ? _max : _min
+console.log(mGet(), utilset(), _map(), maxOrMin())`)
   })
 })

--- a/packages/gulp/treeshaking-lodash.js
+++ b/packages/gulp/treeshaking-lodash.js
@@ -38,16 +38,16 @@ function treeShakingLodash(content) {
   if (importNamespaceSpecifierMap.size > 0) {
     const importNamespaceSpecifierNames = Array.from(importNamespaceSpecifierMap.keys())
     walk.simple(ast, {
-      CallExpression(node) {
-        if (node.callee.type === "MemberExpression" && node.callee.object.type === "Identifier") {
-          const name = node.callee.object.name;
+      MemberExpression(node) {
+        if (node.type === "MemberExpression" && node.object.type === "Identifier") {
+          const name = node.object.name;
           if (importNamespaceSpecifierNames.includes(name)) {
             const { importedSet } = importNamespaceSpecifierMap.get(name)
-            importedSet.add(node.callee.property.name)
-            magicString.overwrite(node.callee.start, node.callee.end, `${name}${node.callee.property.name}`);
+            importedSet.add(node.property.name)
+            magicString.overwrite(node.start, node.end, `${name}${node.property.name}`);
           }
         }
-      }
+      },
     })
     importNamespaceSpecifierMap.forEach(({ start, end, importedSet }, key) => {
       if (importedSet.size > 0) {


### PR DESCRIPTION
修复treeshaking-lodash, 只转换_.get() 未处理 _.get 问题
