### PR TITLE
fix(popup): 🐛Popup 组件初次挂载时会执行 onClose 事件

### DIFF
--- a/packages/core/src/popup/popup.tsx
+++ b/packages/core/src/popup/popup.tsx
@@ -125,13 +125,17 @@ const Popup = forwardRef<any, PopupProps>((props, ref) => {
 
   const { value: open } = useUncontrolled({ defaultValue: defaultOpen, value: openProp })
   const onClosePropRef = useToRef(onClose)
+  const initializedRef = useToRef(open)
   useLockScrollTaro(!!open && lock)
 
   useEffect(() => {
-    if (open === false) {
-      onClosePropRef.current?.(false)
+    if (initializedRef.current) {
+      if (open === false)
+        onClosePropRef.current?.(false)
+    } else {
+      initializedRef.current = true
     }
-  }, [onClosePropRef, open])
+  }, [open])
 
   const transactionName = transaction ?? toTransactionName(placement)
 

--- a/packages/demo/src/pages/basic/popup/index.tsx
+++ b/packages/demo/src/pages/basic/popup/index.tsx
@@ -1,7 +1,7 @@
 import { ScrollView } from "@tarojs/components"
 import { Cell, Popup } from "@taroify/core"
 import { PopupPlacement } from "@taroify/core/popup"
-import { ArrowRight, Close } from "@taroify/icons"
+import { Close } from "@taroify/icons"
 import { CSSProperties, useState } from "react"
 import Block from "../../../components/block"
 import Page from "../../../components/page"


### PR DESCRIPTION
- 在 useEffect 中添加 initializedRef 以判断组件是否已初始化
- 优化 Popup 关闭逻辑，仅在组件初始化后执行关闭回调
- 移除 demo 中未使用的 ArrowRight 图标导入"

✅ Closes: #941 #942