### PR TITLE
fix: 🐛 修复 Transition 组件的 findDOMNode API报错问题

### DIFF
--- a/packages/core/src/transition/transition.tsx
+++ b/packages/core/src/transition/transition.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { isValidElement, type ReactElement, type ReactNode, useMemo, useState } from "react"
+import { cloneElement, isValidElement, type ReactElement, type ReactNode, useMemo, useRef, useState } from "react"
 import { CSSTransition } from "react-transition-group"
 import type { EnterHandler, ExitHandler } from "react-transition-group/Transition"
 import { prefixClassname } from "../styles"
@@ -72,10 +72,16 @@ export default function Transition(props: TransitionProps) {
   const transactionName = isTransitionPreset(name) ? prefixClassname(`transition-${name}`) : name
   const [enter, setEnter] = useState(false)
   const [exited, setExited] = useState(false)
+  const ref = useRef(null);
+
+  const setRef = (value) => {
+    ref.current = value;
+  };
 
   return (
     <CSSTransition
       in={inProp}
+      nodeRef={ref}
       mountOnEnter={mountOnEnter}
       unmountOnExit={unmountOnExit}
       timeout={timeout}
@@ -85,7 +91,6 @@ export default function Transition(props: TransitionProps) {
         ...childrenStyle,
         display: enter && !exited ? "" : "none",
       }}
-      children={children}
       onEnter={(node, isAppearing) => {
         setEnter(true)
         setExited(false)
@@ -102,6 +107,8 @@ export default function Transition(props: TransitionProps) {
         // @ts-ignore
         onExited?.(node)
       }}
-    />
+    >
+      {cloneElement(children as ReactElement, { ref: setRef })}
+    </CSSTransition>
   )
 }


### PR DESCRIPTION
添加 nodeRef 属性，并使用 cloneElement 为子元素添加 ref 属性以解决 React18 findDOMNode API报错问题

✅ Closes: #947

参考: https://github.com/reactjs/react-transition-group/issues/918#issuecomment-2653832792

`react-transition-group`这个库看起来已经不维护很久了