### PR TITLE
fix(Dialog): 未传入 title 时仍然渲染 header 的问题

### DIFF
--- a/packages/core/src/dialog/dialog.tsx
+++ b/packages/core/src/dialog/dialog.tsx
@@ -156,6 +156,9 @@ export interface DialogProps extends ViewProps {
 }
 
 function renderHeader(title, key?) {
+  if (title === undefined) {
+    return null
+  }
   return <DialogHeader key={key} children={title} />
 }
 


### PR DESCRIPTION
在 dialog.tsx 的 renderHeader 中添加了对 title 的空值校验