### PR TITLE
fix: 🐛 (PullRefresh): 在 h5 环境下包裹 List 不能正常滚动的问题

### DIFF
--- a/packages/core/src/pull-refresh/pull-refresh.scss
+++ b/packages/core/src/pull-refresh/pull-refresh.scss
@@ -1,7 +1,7 @@
 @use "./variables" as *;
 
 .#{$component-prefix}pull-refresh {
-  overflow: hidden;
+  overflow: scroll;
   user-select: none;
 
   &__track {


### PR DESCRIPTION
(PullRefresh): 在 h5 环境下包裹 List 不能正常滚动的问题
具体的复现，可以看文档的 List 示例的下拉刷新示例
https://taroify.github.io/taroify.com/components/list/

修改成 scroll 即可解决该问题。
```
.taroify-pull-refresh {
  overflow: scroll;
}
```