### PR TITLE
fix: 🐛 uploader 自定义预览样式异常，增加customUploadButton属性

### DIFF
--- a/packages/core/src/uploader/README.md
+++ b/packages/core/src/uploader/README.md
@@ -143,9 +143,9 @@ function MaxFilesUploader() {
 }
 ```
 
-### 自定义上传样式
+### 自定义上传按钮
 
-通过children可以自定义上传区域的样式。
+通过 `customUploadButton` 可以自定义上传按钮的样式
 
 ```tsx
 function CustomUploader() {
@@ -167,19 +167,27 @@ function CustomUploader() {
     })
   }
   return (
-    <Uploader multiple value={files} onChange={setFiles} onUpload={onUpload}>
-      <Button icon={<Plus />} color="primary">
-        上传文件
-      </Button>
-    </Uploader>
+    <Uploader
+      multiple
+      value={files}
+      onChange={setFiles}
+      onUpload={onUpload}
+      customUploadButton={
+        <Button icon={<Plus />} color="primary">
+          上传文件
+        </Button>
+      }
+    />
   )
 }
 ```
 
-### 自定义预览样式
+### 自定义上传预览样式
 
-通过自定义 `Uploader.Image` 组件可以自定义覆盖在预览区域上方的内容。<br/>
-通过 `Uploader.Upload` 组件触发onUpload
+通过 `React.children` 属性可以定义上传按钮和文件展示形式 <br/>
+通过自定义 `Uploader.Image` 组件可以自定义覆盖在预览区域上方的内容 <br/>
+通过 `Uploader.Upload` 组件触发 `onUpload` <br/>
+自定义预览不应该使用 `value`
 ```tsx
 function CustomPreviewUploader() {
   const [files, setFiles] = useState<Uploader.File[]>([
@@ -205,7 +213,7 @@ function CustomPreviewUploader() {
   }
 
   return (
-    <Uploader value={files} multiple onUpload={onUpload} onChange={setFiles}>
+    <Uploader multiple onUpload={onUpload} onChange={setFiles}>
       {files.map((image) => (
         <Uploader.Image
           key={image.url}

--- a/packages/core/src/uploader/uploader-upload.tsx
+++ b/packages/core/src/uploader/uploader-upload.tsx
@@ -17,7 +17,7 @@ interface UploaderUploadProps extends ViewProps {
 
 function UploaderUpload(props: UploaderUploadProps) {
   const { className, readonly, icon = <Photograph />, onClick, children, ...restProps } = props
-  const { disabled, onUpload } = useContext(UploaderContext)
+  const { disabled, onUpload, customUploadButton } = useContext(UploaderContext)
 
   function handleClick(event: ITouchEvent) {
     onClick?.(event)
@@ -26,8 +26,8 @@ function UploaderUpload(props: UploaderUploadProps) {
     }
   }
 
-  if (children) {
-    return <View onClick={handleClick}>{children}</View>
+  if (children || customUploadButton) {
+    return <View onClick={handleClick}>{children || customUploadButton}</View>
   }
 
   return (

--- a/packages/core/src/uploader/uploader.context.ts
+++ b/packages/core/src/uploader/uploader.context.ts
@@ -1,9 +1,9 @@
-import { createContext } from "react"
+import { createContext, type ReactNode } from "react"
 
 interface UploaderContextValue {
   removable?: boolean
   disabled?: boolean
-
+  customUploadButton?: ReactNode
   onUpload?(): void
 
   onRemove?(): void

--- a/packages/core/src/uploader/uploader.tsx
+++ b/packages/core/src/uploader/uploader.tsx
@@ -13,6 +13,7 @@ import UploaderMask from "./uploader-mask"
 import UploaderUpload from "./uploader-upload"
 import UploaderContext from "./uploader.context"
 import { getOneUploadFile, getUploadFiles, type UploadFile } from "./uploader.shared"
+import { isExitChildren } from "./uploader.utils"
 
 function renderUploaderMask(file: UploadFile) {
   return (
@@ -37,7 +38,7 @@ interface UseUploadFilesRenderProps {
   disabled?: boolean
   multiple?: boolean
   maxFiles?: number
-  children?: ReactNode
+  children?: ReactNode | ReactNode[]
   onChange?(file: UploadFile | UploadFile[]): void
 }
 
@@ -84,24 +85,32 @@ function UploadFilesRender(props: UseUploadFilesRenderProps): JSX.Element {
 
   const files = useMemo(() => {
     if (!multiple) {
-      return []
+      return <></>
     }
+
     const __files__ = _.map(getUploadFiles(value) as UploadFile[], renderImage)
+
     if (__files__.length < maxFiles) {
-      __files__.push(<UploaderUpload key="upload" children={children} />)
+      __files__.push(<UploaderUpload key="upload" />)
     }
-    return __files__ as ReactNode
+
+    return <>{__files__}</>
   }, [maxFiles, multiple, renderImage, value, children])
 
-  if (_.isEmpty(value)) {
-    return <UploaderUpload children={children} />
+  if (_.isEmpty(value) && !isExitChildren(children)) {
+    return <UploaderUpload />
   }
 
   if (!multiple) {
     const file = getOneUploadFile(value)
-    return renderImage(file)
+    return file ? renderImage(file) : <UploaderUpload />
   }
-  return files as JSX.Element
+
+  if (isExitChildren(children)) {
+    return <>{children}</>
+  }
+
+  return files
 }
 
 interface BaseUploaderProps extends ViewProps {
@@ -112,7 +121,8 @@ interface BaseUploaderProps extends ViewProps {
   multiple?: boolean
   maxFiles?: number
   removable?: boolean
-  children?: ReactNode
+  children?: ReactNode | ReactNode[]
+  customUploadButton?: ReactNode
   onUpload?(): void
   onChange?(file: (UploadFile & undefined) | (UploadFile[] & undefined)): void
 }
@@ -128,6 +138,7 @@ export default function Uploader(props: UploaderProps) {
     removable = true,
     maxFiles,
     multiple,
+    customUploadButton,
     children,
     onUpload,
     onChange,
@@ -139,6 +150,7 @@ export default function Uploader(props: UploaderProps) {
       value={{
         removable,
         disabled,
+        customUploadButton,
         onUpload,
       }}
     >

--- a/packages/core/src/uploader/uploader.utils.ts
+++ b/packages/core/src/uploader/uploader.utils.ts
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react"
 import type { UploadFile } from "./uploader.shared"
 
 const IMAGE_REGEXP = /\.(jpeg|jpg|gif|png|svg|webp|jfif|bmp|dpg)/i
@@ -11,4 +12,8 @@ export function isImageFile(item: UploadFile): boolean {
     return IMAGE_REGEXP.test(item.url)
   }
   return false
+}
+
+export const isExitChildren = (children: ReactNode | ReactNode[]): boolean => {
+  return Array.isArray(children) ? children.length > 0 : !!children
 }

--- a/packages/demo/src/pages/form/uploader/index.tsx
+++ b/packages/demo/src/pages/form/uploader/index.tsx
@@ -133,11 +133,17 @@ function CustomUploader() {
     })
   }
   return (
-    <Uploader multiple value={files} onChange={setFiles} onUpload={onUpload}>
-      <Button icon={<Plus />} color="primary">
-        上传文件
-      </Button>
-    </Uploader>
+    <Uploader
+      multiple
+      value={files}
+      onChange={setFiles}
+      onUpload={onUpload}
+      customUploadButton={
+        <Button icon={<Plus />} color="primary">
+          上传文件
+        </Button>
+      }
+    />
   )
 }
 
@@ -165,8 +171,8 @@ function CustomPreviewUploader() {
   }
 
   return (
-    <Uploader value={files} multiple onUpload={onUpload} onChange={setFiles}>
-      {files.map((image) => (
+    <Uploader multiple onUpload={onUpload} onChange={setFiles}>
+      {files?.map((image) => (
         <Uploader.Image
           key={image.url}
           url={image.url}


### PR DESCRIPTION
目前官网的 自定义预览样式 存在bug 图片会渲染两次，原因为：父组件的children 透传至 uploader-upload 子组件导致，修复这个 bug 需要不透传 children 因此和自定义上传样式功能冲突，增加 customUploadButton 来适配这个bug，同时最小化改动，方便之前的用户调整，暂时没想到两边都兼容方法去修复这个 bug