### PR TITLE
fix: 🐛 增加itemRender用来修复使用react chidlren属性时图片重复渲染

### DIFF
--- a/packages/core/src/uploader/README.md
+++ b/packages/core/src/uploader/README.md
@@ -176,10 +176,9 @@ function CustomUploader() {
 }
 ```
 
-### 自定义预览样式
+### 自定义上传列表项
 
-通过自定义 `Uploader.Image` 组件可以自定义覆盖在预览区域上方的内容。<br/>
-通过 `Uploader.Upload` 组件触发onUpload
+通过自定义 `itemrender` 控制每个上传区块
 ```tsx
 function CustomPreviewUploader() {
   const [files, setFiles] = useState<Uploader.File[]>([
@@ -204,21 +203,28 @@ function CustomPreviewUploader() {
     })
   }
 
+  const itemRender = ({ file }: { file: Uploader.File }) => {
+    return (
+      <Uploader.Image
+        key={file.url}
+        url={file.url}
+        name={file.name}
+        type={file.type}
+        onRemove={() => setFiles(files.filter((item) => item !== file))}
+      >
+        <View className="preview-cover taroify-ellipsis">图片名称</View>
+      </Uploader.Image>
+    )
+  }
+
   return (
-    <Uploader value={files} multiple onUpload={onUpload} onChange={setFiles}>
-      {files.map((image) => (
-        <Uploader.Image
-          key={image.url}
-          url={image.url}
-          name={image.name}
-          type={image.type}
-          onRemove={() => setFiles(files.filter((item) => item !== image))}
-        >
-          <View className="preview-cover taroify-ellipsis">图片名称</View>
-        </Uploader.Image>
-      ))}
-      <Uploader.Upload />
-    </Uploader>
+    <Uploader
+      value={files}
+      multiple
+      onUpload={onUpload}
+      onChange={setFiles}
+      itemRender={itemRender}
+    />
   )
 }
 ```

--- a/packages/core/src/uploader/uploader.tsx
+++ b/packages/core/src/uploader/uploader.tsx
@@ -37,8 +37,9 @@ interface UseUploadFilesRenderProps {
   disabled?: boolean
   multiple?: boolean
   maxFiles?: number
-  children?: ReactNode
+  children?: ReactNode | ReactNode[]
   onChange?(file: UploadFile | UploadFile[]): void
+  itemRender?({ file }: { file: UploadFile }): ReactNode
 }
 
 function UploadFilesRender(props: UseUploadFilesRenderProps): JSX.Element {
@@ -50,6 +51,7 @@ function UploadFilesRender(props: UseUploadFilesRenderProps): JSX.Element {
     maxFiles = Number.MAX_VALUE,
     children,
     onChange: onChangeProp,
+    itemRender,
   } = props
 
   const { value = [], setValue } = useUncontrolled({
@@ -82,17 +84,6 @@ function UploadFilesRender(props: UseUploadFilesRenderProps): JSX.Element {
     [disabled, multiple, setValue, value],
   )
 
-  const files = useMemo(() => {
-    if (!multiple) {
-      return []
-    }
-    const __files__ = _.map(getUploadFiles(value) as UploadFile[], renderImage)
-    if (__files__.length < maxFiles) {
-      __files__.push(<UploaderUpload key="upload" children={children} />)
-    }
-    return __files__ as ReactNode
-  }, [maxFiles, multiple, renderImage, value, children])
-
   if (_.isEmpty(value)) {
     return <UploaderUpload children={children} />
   }
@@ -101,7 +92,18 @@ function UploadFilesRender(props: UseUploadFilesRenderProps): JSX.Element {
     const file = getOneUploadFile(value)
     return renderImage(file)
   }
-  return files as JSX.Element
+
+  return (
+    <>
+      {getUploadFiles(value).map((file, index) => {
+        return itemRender ? itemRender({ file }) : renderImage(file, index)
+      })}
+
+      {getUploadFiles(value).length < maxFiles && (
+        <UploaderUpload key="upload" children={children} />
+      )}
+    </>
+  )
 }
 
 interface BaseUploaderProps extends ViewProps {
@@ -112,9 +114,10 @@ interface BaseUploaderProps extends ViewProps {
   multiple?: boolean
   maxFiles?: number
   removable?: boolean
-  children?: ReactNode
+  children?: ReactNode | ReactNode[]
   onUpload?(): void
   onChange?(file: (UploadFile & undefined) | (UploadFile[] & undefined)): void
+  itemRender?({ file }: { file: UploadFile }): ReactNode
 }
 
 export type UploaderProps = BaseUploaderProps
@@ -131,6 +134,7 @@ export default function Uploader(props: UploaderProps) {
     children,
     onUpload,
     onChange,
+    itemRender,
     ...restProps
   } = props
 
@@ -155,6 +159,7 @@ export default function Uploader(props: UploaderProps) {
             maxFiles={maxFiles}
             multiple={multiple}
             onChange={onChange}
+            itemRender={itemRender}
             children={children}
           />
         </View>

--- a/packages/demo/src/pages/form/uploader/index.tsx
+++ b/packages/demo/src/pages/form/uploader/index.tsx
@@ -164,21 +164,28 @@ function CustomPreviewUploader() {
     })
   }
 
+  const itemRender = ({ file }: { file: Uploader.File }) => {
+    return (
+      <Uploader.Image
+        key={file.url}
+        url={file.url}
+        name={file.name}
+        type={file.type}
+        onRemove={() => setFiles(files.filter((item) => item !== file))}
+      >
+        <View className="preview-cover taroify-ellipsis">图片名称</View>
+      </Uploader.Image>
+    )
+  }
+
   return (
-    <Uploader value={files} multiple onUpload={onUpload} onChange={setFiles}>
-      {files.map((image) => (
-        <Uploader.Image
-          key={image.url}
-          url={image.url}
-          name={image.name}
-          type={image.type}
-          onRemove={() => setFiles(files.filter((item) => item !== image))}
-        >
-          <View className="preview-cover taroify-ellipsis">图片名称</View>
-        </Uploader.Image>
-      ))}
-      <Uploader.Upload />
-    </Uploader>
+    <Uploader
+      value={files}
+      multiple
+      onUpload={onUpload}
+      onChange={setFiles}
+      itemRender={itemRender}
+    />
   )
 }
 
@@ -204,7 +211,7 @@ export default function UploaderDemo() {
       <Block title="自定义上传样式">
         <CustomUploader />
       </Block>
-      <Block title="自定义预览样式">
+      <Block title="自定义上传列表项">
         <CustomPreviewUploader />
       </Block>
       <Block title="禁用文件上传">


### PR DESCRIPTION
✅ Closes: #965
官网自定义渲染例子存在bug
children被透传至UploaderUpload使用，当children不止为上传按钮，存在UploaderImage时会重复渲染。
修复这个 bug 需要不透传 children 与“自定义上传样式”示例实现冲突
增加 itemRender 用来实现自定义上传项，兼容老代码
0.4.1版本 uploader 调整导致