### PR TITLE
chore: fix ci node engine error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20.11.1'
+          node-version: '20.18.1'
 
       - name: Install
         run: |
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20.11.1'
+          node-version: '20.18.1'
 
       - name: Install
         run: |


### PR DESCRIPTION
```
error undici@7.11.0: The engine "node" is incompatible with this module. Expected version ">=20.18.1". Got "20.11.1"
```