### PR TITLE
Add valueClass prop to CellValue component

### DIFF
--- a/packages/core/src/cell/cell.tsx
+++ b/packages/core/src/cell/cell.tsx
@@ -22,7 +22,7 @@ function Cell(props: CellProps) {
           {brief && <CellBrief children={brief} briefClass={briefClass} />}
         </CellTitle>
       )}
-      <CellValue alone={!title} children={children} />
+      <CellValue alone={!title} children={children} valueClass={valueClass} />
     </CellBase>
   )
 }


### PR DESCRIPTION
`Cell` 忘记把 `valueClass` 传递给 `CellValue`