### PR TITLE
fix(Cell): 🐛 修复 Cell当 title 和 value 并存时value内容溢出的问题；修复 Cell 只有 value 时宽度没有撑开的问题

### DIFF
--- a/packages/core/src/cell/cell.scss
+++ b/packages/core/src/cell/cell.scss
@@ -76,11 +76,11 @@
   }
 
   &__value {
-    flex:  0 0 auto;
     color: $cell-value-color;
     text-align: right;
 
     &--alone {
+      flex: 1;
       color: $text-color;
       text-align: left;
     }


### PR DESCRIPTION
 修复 Cell当 title 和 value 并存时value内容溢出的问题；修复 Cell 只有 value 时宽度没有撑开的问题

内容溢出：
<img width="441" height="78" alt="image" src="https://github.com/user-attachments/assets/105631ec-7ede-4ed9-9ad4-84d8cae2bd21" />

宽度没有撑开：
当前：
<img width="426" height="246" alt="image" src="https://github.com/user-attachments/assets/98b9e97d-430d-478a-aed0-4d5cf25439a9" />
修复后：
<img width="432" height="206" alt="image" src="https://github.com/user-attachments/assets/081da9d1-3e6c-45a1-a565-bb4bfc435a89" />

