### PR TITLE
fix: 🐛 修复官网自定义域名配置

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,7 +9,7 @@ body:
         ## 感谢您的反馈！
         在提交问题之前，请确保您使用的是所有最新版本 @taroify/* 包，或者优先使用以下方式寻找解决方案：
 
-        - 查看组件文档 [@taroify/core](https://taroify.github.io/taroify.com/introduce)
+        - 查看组件文档 [@taroify/core](https://taroify.com/introduce)
         - 在 [Issue](https://github.com/taroify/taroify/issues?q=is%3Aissue) 列表中查找解决方案
 
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,7 +9,7 @@ body:
         ## 感谢您伸出援手！
         在提交问题之前，请确保您使用的是所有最新版本 @taroify/* 包，或者优先使用以下方式寻找解决方案：
 
-        - 查看组件文档 [@taroify/core](https://taroify.github.io/taroify.com/introduce)
+        - 查看组件文档 [@taroify/core](https://taroify.com/introduce)
         - 在 [Issue](https://github.com/taroify/taroify/issues?q=is%3Aissue) 列表中查找解决方案
 
   - type: textarea

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@
   </p>
 
   <p>
-    <a href="https://taroify.github.io/taroify.com/"><strong>官网</strong></a>
+    <a href="https://taroify.com/"><strong>官网</strong></a>
     ·
-    <a href="https://taroify.github.io/taroify.com/quickstart/"><strong>快速上手</strong></a>
+    <a href="https://taroify.com/quickstart/"><strong>快速上手</strong></a>
     ·
-    <a href="https://taroify.github.io/taroify.com/h5/index.html"><strong>在线演示</strong></a>
+    <a href="https://taroify.com/h5/index.html"><strong>在线演示</strong></a>
     ·
-    <a href="https://taroify.github.io/taroify.com/cli/"><strong>CLI / MCP</strong></a>
+    <a href="https://taroify.com/cli/"><strong>CLI / MCP</strong></a>
     ·
     <a href="https://github.com/taroify/taroify/discussions"><strong>讨论区</strong></a>
   </p>
@@ -94,7 +94,7 @@ export default function Index() {
 ```
 
 推荐配置自动按需引入，以获得更简洁的源码和更小的构建产物。完整配置请查看
-[快速上手](https://taroify.github.io/taroify.com/quickstart/)。
+[快速上手](https://taroify.com/quickstart/)。
 
 ## Packages
 
@@ -124,7 +124,7 @@ pnpm develop
 ```
 
 更多仓库结构、组件开发与提交规范，请阅读
-[贡献指南](https://taroify.github.io/taroify.com/contribution/)。
+[贡献指南](https://taroify.com/contribution/)。
 
 ## 社区
 
@@ -133,7 +133,7 @@ pnpm develop
 - [提交 Issue](https://github.com/mallftaroifyoundry/taroify/issues)
 - [发起 Pull Request](https://github.com/taroify/taroify/pulls)
 - [参与 Discussions](https://github.com/taroify/taroify/discussions)
-- [查看更新日志](https://taroify.github.io/taroify.com/changelog/)
+- [查看更新日志](https://taroify.com/changelog/)
 
 <details>
   <summary><strong>加入微信交流群</strong></summary>

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,7 +12,7 @@
     "ai-coding",
     "react-components"
   ],
-  "homepage": "https://taroify.github.io/taroify.com/cli/",
+  "homepage": "https://taroify.com/cli/",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/taroify/taroify.git",

--- a/packages/commerce/README.md
+++ b/packages/commerce/README.md
@@ -16,6 +16,6 @@ yarn add @taroify/commerce
 
 ## Document
 
-- [Usage in Taro](https://taroify.github.io/taroify.com/introduce/)
+- [Usage in Taro](https://taroify.com/introduce/)
 - [Usage in Vue](https://vant-contrib.gitee.io/vant/#/zh-CN/)
 - [Usage in Weapp](https://vant-contrib.gitee.io/vant-weapp/#/home)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -29,13 +29,13 @@
   </p>
 
   <p>
-    <a href="https://taroify.github.io/taroify.com/"><strong>官网</strong></a>
+    <a href="https://taroify.com/"><strong>官网</strong></a>
     ·
-    <a href="https://taroify.github.io/taroify.com/quickstart/"><strong>快速上手</strong></a>
+    <a href="https://taroify.com/quickstart/"><strong>快速上手</strong></a>
     ·
-    <a href="https://taroify.github.io/taroify.com/h5/index.html"><strong>在线演示</strong></a>
+    <a href="https://taroify.com/h5/index.html"><strong>在线演示</strong></a>
     ·
-    <a href="https://taroify.github.io/taroify.com/cli/"><strong>CLI / MCP</strong></a>
+    <a href="https://taroify.com/cli/"><strong>CLI / MCP</strong></a>
     ·
     <a href="https://github.com/taroify/taroify/discussions"><strong>讨论区</strong></a>
   </p>
@@ -94,7 +94,7 @@ export default function Index() {
 ```
 
 推荐配置自动按需引入，以获得更简洁的源码和更小的构建产物。完整配置请查看
-[快速上手](https://taroify.github.io/taroify.com/quickstart/)。
+[快速上手](https://taroify.com/quickstart/)。
 
 ## Packages
 
@@ -124,7 +124,7 @@ pnpm develop
 ```
 
 更多仓库结构、组件开发与提交规范，请阅读
-[贡献指南](https://taroify.github.io/taroify.com/contribution/)。
+[贡献指南](https://taroify.com/contribution/)。
 
 ## 社区
 
@@ -133,7 +133,7 @@ pnpm develop
 - [提交 Issue](https://github.com/taroify/taroify/issues)
 - [发起 Pull Request](https://github.com/taroify/taroify/pulls)
 - [参与 Discussions](https://github.com/taroify/taroify/discussions)
-- [查看更新日志](https://taroify.github.io/taroify.com/changelog/)
+- [查看更新日志](https://taroify.com/changelog/)
 
 <details>
   <summary><strong>加入微信交流群</strong></summary>

--- a/packages/demo/config/index.js
+++ b/packages/demo/config/index.js
@@ -146,7 +146,7 @@ const config = {
       include: workspaceSourceDirs,
     },
     esnextModules: ["@taroify"],
-    publicPath: process.env.NODE_ENV === "development" ? "/" : "/taroify.com/h5",
+    publicPath: process.env.NODE_ENV === "development" ? "/" : "/h5",
     staticDirectory: "static",
     postcss: {
       autoprefixer: {

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -16,6 +16,6 @@ yarn add @taroify/icons
 
 ## Document
 
-- [Usage in Taro](https://taroify.github.io/taroify.com/components/icon/)
+- [Usage in Taro](https://taroify.com/components/icon/)
 - [Usage in Vue](https://youzan.github.io/vant/#/zh-CN/icon)
 - [Usage in Weapp](https://youzan.github.io/vant-weapp/#/icon)

--- a/site/assets/CNAME
+++ b/site/assets/CNAME
@@ -1,0 +1,1 @@
+taroify.com

--- a/site/content/agents/index.md
+++ b/site/content/agents/index.md
@@ -10,7 +10,7 @@ MCP 和 LLMs.txt 获取准确的 Taroify 组件知识。
 ```text
 你正在为 Taro React 项目使用 Taroify。你训练数据中的组件 API、事件、子组件和主题变量
 可能与当前版本不同。在编写或修改代码前，请先阅读
-https://taroify.github.io/taroify.com/agents/index.md
+https://taroify.com/agents/index.md
 以及
 https://raw.githubusercontent.com/mallfoundry/taroify/main/packages/cli/skills/taroify/SKILL.md，
 查询真实 API 和示例，不要猜测组件用法。
@@ -74,9 +74,9 @@ Resources 和任务 Prompts。支持 MCP 的 Agent 可以自动查询所需内�
 
 | 文件 | 说明 |
 | --- | --- |
-| [llms.txt](https://taroify.github.io/taroify.com/llms.txt) | 官网文档索引，适合先定位相关页面 |
-| [llms-full.txt](https://taroify.github.io/taroify.com/llms-full.txt) | 完整官网文档，适合离线索引或全局分析 |
-| [Button 文档](https://taroify.github.io/taroify.com/components/button/index.md) | 单个组件的介绍、示例、API 和主题变量 |
+| [llms.txt](https://taroify.com/llms.txt) | 官网文档索引，适合先定位相关页面 |
+| [llms-full.txt](https://taroify.com/llms-full.txt) | 完整官网文档，适合离线索引或全局分析 |
+| [Button 文档](https://taroify.com/components/button/index.md) | 单个组件的介绍、示例、API 和主题变量 |
 
 更多读取方式请参考 [LLMs.txt 文档](/llms/)。
 

--- a/site/content/introduce/index.md
+++ b/site/content/introduce/index.md
@@ -11,13 +11,13 @@
   </p>
   <p>
     <span>
-      <a href="https://taroify.github.io/taroify.com/"><strong>官网</strong></a>
+      <a href="https://taroify.com/"><strong>官网</strong></a>
       {" · "}
-      <a href="https://taroify.github.io/taroify.com/quickstart/"><strong>快速上手</strong></a>
+      <a href="https://taroify.com/quickstart/"><strong>快速上手</strong></a>
       {" · "}
-      <a href="https://taroify.github.io/taroify.com/h5/index.html"><strong>在线演示</strong></a>
+      <a href="https://taroify.com/h5/index.html"><strong>在线演示</strong></a>
       {" · "}
-      <a href="https://taroify.github.io/taroify.com/cli/"><strong>CLI / MCP</strong></a>
+      <a href="https://taroify.com/cli/"><strong>CLI / MCP</strong></a>
       {" · "}
       <a href="https://github.com/taroify/taroify/discussions"><strong>讨论区</strong></a>
     </span>
@@ -71,7 +71,7 @@ export default function Index() {
 ```
 
 推荐配置自动按需引入，以获得更简洁的源码和更小的构建产物。完整配置请查看
-[快速上手](https://taroify.github.io/taroify.com/quickstart/)。
+[快速上手](https://taroify.com/quickstart/)。
 
 ## Packages
 
@@ -101,7 +101,7 @@ pnpm develop
 ```
 
 更多仓库结构、组件开发与提交规范，请阅读
-[贡献指南](https://taroify.github.io/taroify.com/contribution/)。
+[贡献指南](https://taroify.com/contribution/)。
 
 ## 社区
 
@@ -110,7 +110,7 @@ pnpm develop
 - [提交 Issue](https://github.com/mataroifyllfoundry/taroify/issues)
 - [发起 Pull Request](https://github.com/taroify/taroify/pulls)
 - [参与 Discussions](https://github.com/taroify/taroify/discussions)
-- [查看更新日志](https://taroify.github.io/taroify.com/changelog/)
+- [查看更新日志](https://taroify.com/changelog/)
 
 <details>
   <summary><strong>加入微信交流群</strong></summary>

--- a/site/content/llms/index.md
+++ b/site/content/llms/index.md
@@ -6,16 +6,16 @@ Taroify 为 AI 编码助手提供结构化的 Markdown 文档入口。你可以�
 
 | 资源 | 地址 | 用途 |
 | --- | --- | --- |
-| 文档索引 | [llms.txt](https://taroify.github.io/taroify.com/llms.txt) | 按官网导航列出页面标题、摘要和 Markdown 地址 |
-| 完整文档 | [llms-full.txt](https://taroify.github.io/taroify.com/llms-full.txt) | 在单个文件中提供全部官网文档，适合离线索引或全局分析 |
-| 单页文档 | [Button 文档](https://taroify.github.io/taroify.com/components/button/index.md) | 只读取一个组件的介绍、示例、API 和主题变量 |
+| 文档索引 | [llms.txt](https://taroify.com/llms.txt) | 按官网导航列出页面标题、摘要和 Markdown 地址 |
+| 完整文档 | [llms-full.txt](https://taroify.com/llms-full.txt) | 在单个文件中提供全部官网文档，适合离线索引或全局分析 |
+| 单页文档 | [Button 文档](https://taroify.com/components/button/index.md) | 只读取一个组件的介绍、示例、API 和主题变量 |
 
 每个官网文档页面都有对应的 Markdown 文件。例如：
 
 ```text
-https://taroify.github.io/taroify.com/quickstart/index.md
-https://taroify.github.io/taroify.com/components/form/index.md
-https://taroify.github.io/taroify.com/hooks/use-cascader/index.md
+https://taroify.com/quickstart/index.md
+https://taroify.com/components/form/index.md
+https://taroify.com/hooks/use-cascader/index.md
 ```
 
 ## 推荐读取方式
@@ -29,7 +29,7 @@ https://taroify.github.io/taroify.com/hooks/use-cascader/index.md
 例如，让 AI 使用 Taroify 编写页面时可以提供以下指令：
 
 ```text
-先阅读 https://taroify.github.io/taroify.com/llms.txt，
+先阅读 https://taroify.com/llms.txt，
 再按需读取其中的组件 Markdown 文档。
 请只使用文档中存在的 Taroify 组件、Props、事件和主题变量，
 为 Taro React 项目生成代码。
@@ -38,7 +38,7 @@ https://taroify.github.io/taroify.com/hooks/use-cascader/index.md
 查询单个组件时可以直接指定页面：
 
 ```text
-阅读 https://taroify.github.io/taroify.com/components/button/index.md，
+阅读 https://taroify.com/components/button/index.md，
 根据文档说明使用 Taroify Button 完成提交按钮和加载状态。
 ```
 
@@ -50,6 +50,6 @@ https://taroify.github.io/taroify.com/hooks/use-cascader/index.md
 需要避免每次手动提供 URL 时，可以将下面的规则加入项目的 Agent 指令：
 
 ```text
-阅读 `https://taroify.github.io/taroify.com/llms.txt` 并理解 Taroify 组件库，
+阅读 `https://taroify.com/llms.txt` 并理解 Taroify 组件库，
 在编写 Taroify 代码时使用这些知识。
 ```

--- a/site/rspress.config.ts
+++ b/site/rspress.config.ts
@@ -3,8 +3,7 @@ import { defineConfig } from "@rspress/core"
 import { pluginAlgolia } from "@rspress/plugin-algolia"
 import { pluginSitemap } from "@rspress/plugin-sitemap"
 
-const production = process.env.NODE_ENV === "production"
-const base = process.env.TAROIFY_SITE_BASE || (production ? "/taroify.com/" : "/")
+const base = process.env.TAROIFY_SITE_BASE || "/"
 
 export default defineConfig({
   root: path.join(__dirname, ".generated/docs"),
@@ -13,7 +12,7 @@ export default defineConfig({
   description: "轻量、可靠的小程序端 Taro React UI 组件库",
   lang: "zh",
   base,
-  siteOrigin: "https://taroify.github.io",
+  siteOrigin: "https://taroify.com",
   llms: true,
   icon: "/favicon.svg",
   logo: "/logo.svg",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The documentation site is now available at `https://taroify.com`.
  * Added custom-domain support and updated sitemap links.
  * Production H5 paths now use the streamlined `/h5` route.

* **Documentation**
  * Updated website, quick-start, demo, CLI, contribution, changelog, and component links to the new domain across project documentation and templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->